### PR TITLE
v0.1.9 Fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 <div align="center">
   <br/>
   <img src="./docs/logo.png"/>
-  <p>v0.1.8 (experimental)</p>
+  <p>v0.1.9 (experimental)</p>
   <br/>
   <br/>
   <p>
@@ -17,7 +17,7 @@
         <img src="https://img.shields.io/badge/maintainer-wes4m-blue"/>
     </a>
     <a href="https://badge.fury.io/js/zatca-xml-js">
-      <img src="https://badge.fury.io/js/zatca-xml-js.svg/?v=0.1.8"/>
+      <img src="https://badge.fury.io/js/zatca-xml-js.svg/?v=0.1.9"/>
     </a>
   </p>
   

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "zatca-xml-js",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "zatca-xml-js",
-      "version": "0.1.8",
+      "version": "0.1.9",
       "license": "MIT",
       "dependencies": {
         "@fidm/x509": "^1.2.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,9 +1,13 @@
 {
   "name": "zatca-xml-js",
+  "version": "0.1.8",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
+      "name": "zatca-xml-js",
+      "version": "0.1.8",
+      "license": "MIT",
       "dependencies": {
         "@fidm/x509": "^1.2.1",
         "axios": "^0.27.2",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,9 @@
   "version": "0.1.8",
   "description": "An implementation of Saudi Arabia ZATCA's E-Invoicing requirements, processes, and standards.",
   "main": "lib/index.js",
-  "files": ["lib/**/*"],
+  "files": [
+    "lib/**/*"
+  ],
   "scripts": {
     "build": "tsc --project tsconfig.build.json",
     "test": "tsc && node testing_lib/tests/test.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zatca-xml-js",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "description": "An implementation of Saudi Arabia ZATCA's E-Invoicing requirements, processes, and standards.",
   "main": "lib/index.js",
   "files": [

--- a/src/examples/full.ts
+++ b/src/examples/full.ts
@@ -60,6 +60,10 @@ const invoice = new ZATCASimplifiedTaxInvoice({
 const main = async () => {
     try {
 
+        // TEMP_FOLDER: Use .env or set directly here (Default: /tmp/)
+        // Enable for windows
+        // process.env.TEMP_FOLDER = `${require("os").tmpdir()}\\`;
+
         // Init a new EGS
         const egs = new EGS(egsunit);
 

--- a/src/zatca/egs/index.ts
+++ b/src/zatca/egs/index.ts
@@ -84,8 +84,8 @@ const generateCSR = async (egs_info: EGSUnitInfo, production: boolean, solution_
     // This creates a temporary private file, and csr config file to pass to OpenSSL in order to create and sign the CSR.
     // * In terms of security, this is very bad as /tmp can be accessed by all users. a simple watcher by unauthorized user can retrieve the keys.
     // Better change it to some protected dir.
-    const private_key_file = `/tmp/${uuidv4()}.pem`;
-    const csr_config_file = `/tmp/${uuidv4()}.cnf`;
+    const private_key_file = `${process.env.TEMP_FOLDER ?? "/tmp/"}${uuidv4()}.pem`;
+    const csr_config_file = `${process.env.TEMP_FOLDER ?? "/tmp/"}${uuidv4()}.cnf`;
     fs.writeFileSync(private_key_file, egs_info.private_key);
     fs.writeFileSync(csr_config_file, defaultCSRConfig({
         egs_model: egs_info.model,

--- a/src/zatca/qr/index.ts
+++ b/src/zatca/qr/index.ts
@@ -42,7 +42,7 @@ export const generateQR = ({invoice_xml, digital_signature, public_key, certific
     const formatted_datetime = moment(datetime).format("YYYY-MM-DDTHH:mm:ss")+"Z";
     
     const qr_tlv = TLV([
-        Buffer.from(seller_name as String),
+        seller_name,
         VAT_number,
         formatted_datetime,
         invoice_total,
@@ -78,7 +78,7 @@ export const generateQR = ({invoice_xml, digital_signature, public_key, certific
     const formatted_datetime = moment(datetime).format("YYYY-MM-DDTHH:mm:ss")+"Z";
     
     const qr_tlv = TLV([
-        Buffer.from(seller_name as String),
+        seller_name,
         VAT_number,
         formatted_datetime,
         invoice_total,

--- a/src/zatca/qr/index.ts
+++ b/src/zatca/qr/index.ts
@@ -92,7 +92,8 @@ export const generateQR = ({invoice_xml, digital_signature, public_key, certific
 const TLV = (tags: any[]): Buffer => {
     const tlv_tags: Buffer[] = []
     tags.forEach((tag, i) => {
-        const current_tlv_value: Buffer = Buffer.from([i+1, tag.length, ...Buffer.from(tag)]);
+        const tagValueBuffer: Buffer = Buffer.from(tag);
+        const current_tlv_value: Buffer = Buffer.from([i+1, tagValueBuffer.byteLength, ...tagValueBuffer]);
         tlv_tags.push(current_tlv_value)
     });
     return Buffer.concat(tlv_tags);

--- a/src/zatca/qr/index.ts
+++ b/src/zatca/qr/index.ts
@@ -42,7 +42,7 @@ export const generateQR = ({invoice_xml, digital_signature, public_key, certific
     const formatted_datetime = moment(datetime).format("YYYY-MM-DDTHH:mm:ss")+"Z";
     
     const qr_tlv = TLV([
-        seller_name,
+        Buffer.from(seller_name as String),
         VAT_number,
         formatted_datetime,
         invoice_total,
@@ -78,7 +78,7 @@ export const generateQR = ({invoice_xml, digital_signature, public_key, certific
     const formatted_datetime = moment(datetime).format("YYYY-MM-DDTHH:mm:ss")+"Z";
     
     const qr_tlv = TLV([
-        seller_name,
+        Buffer.from(seller_name as String),
         VAT_number,
         formatted_datetime,
         invoice_total,

--- a/src/zatca/signing/index.ts
+++ b/src/zatca/signing/index.ts
@@ -118,8 +118,7 @@ export const getCertificateInfo = (certificate_string: string): {hash: string, i
  * @returns String base64 encoded certificate body.
  */
 export const cleanUpCertificateString = (certificate_string: string): string => {
-    const r = process.platform === "win32" ? "\r" : "";
-    return certificate_string.replace(`-----BEGIN CERTIFICATE-----${r}\n`, "").replace("-----END CERTIFICATE-----", "").trim()
+    return certificate_string.replace(`-----BEGIN CERTIFICATE-----\n`, "").replace("-----END CERTIFICATE-----", "").trim()
 }
 
 /**
@@ -128,8 +127,7 @@ export const cleanUpCertificateString = (certificate_string: string): string => 
  * @returns String base64 encoded private key body.
  */
  export const cleanUpPrivateKeyString = (certificate_string: string): string => {
-    const r = process.platform === "win32" ? "\r" : "";
-    return certificate_string.replace(`-----BEGIN EC PRIVATE KEY-----${r}\n`, "").replace("-----END EC PRIVATE KEY-----", "").trim()
+    return certificate_string.replace(`-----BEGIN EC PRIVATE KEY-----\n`, "").replace("-----END EC PRIVATE KEY-----", "").trim()
 }
 
 


### PR DESCRIPTION
- [x] Reverting windows OpenSSL trailing PEM key `\r` issue.
I have tested this with multiple windows devices. And it was causing issues because the OpenSSL version did not add a `\r` as expected. So this seems like a rare issue that happened on one device thus I'm reverting it. If you have this issue then modify the lib manually.

- [x] Adding custom TEMP_FOLDER through environment vars.
- [x] Support for other languages in seller_name (UTF-8). 